### PR TITLE
[WIP] Add support for putting indexed scripts into elasticsearch

### DIFF
--- a/src/main/asciidoc/cheatsheet/PutIndexedScriptOptions.adoc
+++ b/src/main/asciidoc/cheatsheet/PutIndexedScriptOptions.adoc
@@ -1,0 +1,18 @@
+== PutIndexedScriptOptions
+
+++++
+ PutIndexedScript operation options
+++++
+'''
+
+[cols=">25%,^25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+
+|[[scriptLang]]`scriptLang`
+|`String`
+|-
+|[[id]]`id`
+|`String`
+|-|===

--- a/src/main/generated/com/englishtown/vertx/elasticsearch/ElasticSearchServiceVertxEBProxy.java
+++ b/src/main/generated/com/englishtown/vertx/elasticsearch/ElasticSearchServiceVertxEBProxy.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import io.vertx.serviceproxy.ProxyHelper;
+import com.englishtown.vertx.elasticsearch.PutIndexedScriptOptions;
 import com.englishtown.vertx.elasticsearch.DeleteOptions;
 import io.vertx.core.Vertx;
 import com.englishtown.vertx.elasticsearch.GetOptions;
@@ -176,6 +177,24 @@ public class ElasticSearchServiceVertxEBProxy implements ElasticSearchService {
     _json.put("options", options == null ? null : options.toJson());
     DeliveryOptions _deliveryOptions = new DeliveryOptions();
     _deliveryOptions.addHeader("action", "delete");
+    _vertx.eventBus().<JsonObject>send(_address, _json, _deliveryOptions, res -> {
+      if (res.failed()) {
+        resultHandler.handle(Future.failedFuture(res.cause()));
+      } else {
+        resultHandler.handle(Future.succeededFuture(res.result().body()));
+      }
+    });
+  }
+
+  public void putIndexedScript(PutIndexedScriptOptions options, Handler<AsyncResult<JsonObject>> resultHandler) {
+    if (closed) {
+      resultHandler.handle(Future.failedFuture(new IllegalStateException("Proxy is closed")));
+      return;
+    }
+    JsonObject _json = new JsonObject();
+    _json.put("options", options == null ? null : options.toJson());
+    DeliveryOptions _deliveryOptions = new DeliveryOptions();
+    _deliveryOptions.addHeader("action", "putIndexedScript");
     _vertx.eventBus().<JsonObject>send(_address, _json, _deliveryOptions, res -> {
       if (res.failed()) {
         resultHandler.handle(Future.failedFuture(res.cause()));

--- a/src/main/generated/com/englishtown/vertx/elasticsearch/ElasticSearchServiceVertxProxyHandler.java
+++ b/src/main/generated/com/englishtown/vertx/elasticsearch/ElasticSearchServiceVertxProxyHandler.java
@@ -37,6 +37,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import io.vertx.serviceproxy.ProxyHelper;
 import io.vertx.serviceproxy.ProxyHandler;
+import com.englishtown.vertx.elasticsearch.PutIndexedScriptOptions;
 import com.englishtown.vertx.elasticsearch.DeleteOptions;
 import io.vertx.core.Vertx;
 import com.englishtown.vertx.elasticsearch.GetOptions;
@@ -152,6 +153,10 @@ public class ElasticSearchServiceVertxProxyHandler extends ProxyHandler {
       }
       case "delete": {
         service.delete((java.lang.String)json.getValue("index"), (java.lang.String)json.getValue("type"), (java.lang.String)json.getValue("id"), json.getJsonObject("options") == null ? null : new com.englishtown.vertx.elasticsearch.DeleteOptions(json.getJsonObject("options")), createHandler(msg));
+        break;
+      }
+      case "putIndexedScript": {
+        service.putIndexedScript(json.getJsonObject("options") == null ? null : new com.englishtown.vertx.elasticsearch.PutIndexedScriptOptions(json.getJsonObject("options")), createHandler(msg));
         break;
       }
       default: {

--- a/src/main/java/com/englishtown/vertx/elasticsearch/ElasticSearchService.java
+++ b/src/main/java/com/englishtown/vertx/elasticsearch/ElasticSearchService.java
@@ -136,4 +136,12 @@ public interface ElasticSearchService {
      */
     void delete(String index, String type, String id, DeleteOptions options, Handler<AsyncResult<JsonObject>> resultHandler);
 
+    /**
+     * Indexes a script on elasticsearch
+     *
+     * @param options       the options for the script
+     * @param resultHandler result handler callback
+     */
+    void putIndexedScript(PutIndexedScriptOptions options, Handler<AsyncResult<JsonObject>> resultHandler);
+
 }

--- a/src/main/java/com/englishtown/vertx/elasticsearch/PutIndexedScriptOptions.java
+++ b/src/main/java/com/englishtown/vertx/elasticsearch/PutIndexedScriptOptions.java
@@ -1,0 +1,72 @@
+package com.englishtown.vertx.elasticsearch;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * PutIndexedScript operation options
+ */
+@DataObject
+public class PutIndexedScriptOptions {
+
+    private String scriptLang;
+    private String id;
+    private JsonObject source;
+
+    public static final String JSON_FIELD_SCRIPT_LANG= "lang";
+    public static final String JSON_FIELD_ID= "id";
+    public static final String JSON_FIELD_SOURCE= "source";
+
+    public PutIndexedScriptOptions() {
+    }
+
+    public PutIndexedScriptOptions(PutIndexedScriptOptions other) {
+        this.scriptLang = other.getScriptLang();
+        this.id = other.getId();
+        this.source = other.getSource();
+    }
+
+    public PutIndexedScriptOptions(JsonObject json) {
+        scriptLang = json.getString(JSON_FIELD_SCRIPT_LANG);
+        id = json.getString(JSON_FIELD_ID);
+        source = json.getJsonObject(JSON_FIELD_SOURCE);
+    }
+
+    public String getScriptLang() {
+        return scriptLang;
+    }
+
+    public PutIndexedScriptOptions setScriptLang(String scriptLang) {
+        this.scriptLang = scriptLang;
+        return this;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public PutIndexedScriptOptions setId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    public JsonObject getSource() {
+        return source;
+    }
+
+    public PutIndexedScriptOptions setSource(JsonObject source) {
+        this.source = source;
+        return this;
+    }
+
+    public JsonObject toJson() {
+
+        JsonObject json = new JsonObject();
+
+        if (scriptLang != null) json.put(JSON_FIELD_SCRIPT_LANG, scriptLang);
+        if (id != null) json.put(JSON_FIELD_ID, id);
+        if (source != null) json.put(JSON_FIELD_SOURCE, source);
+
+        return json;
+    }
+}

--- a/src/main/java/com/englishtown/vertx/elasticsearch/impl/DefaultElasticSearchService.java
+++ b/src/main/java/com/englishtown/vertx/elasticsearch/impl/DefaultElasticSearchService.java
@@ -12,6 +12,8 @@ import org.elasticsearch.action.get.GetRequestBuilder;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.indexedscripts.put.PutIndexedScriptRequestBuilder;
+import org.elasticsearch.action.indexedscripts.put.PutIndexedScriptResponse;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchScrollRequestBuilder;
@@ -44,6 +46,8 @@ public class DefaultElasticSearchService implements ElasticSearchService {
     public static final String CONST_VERSION = "version";
     public static final String CONST_SOURCE = "source";
     public static final String CONST_CREATED = "created";
+    public static final String CONST_IS_CREATED = "isCreated";
+    public static final String CONST_SCRIPT_LANG = "lang";
 
     public static final Charset CHARSET_UTF8 = Charset.forName("UTF-8");
 
@@ -320,6 +324,36 @@ public class DefaultElasticSearchService implements ElasticSearchService {
             }
         });
 
+    }
+
+    @Override
+    public void putIndexedScript(PutIndexedScriptOptions options, Handler<AsyncResult<JsonObject>> resultHandler) {
+
+        PutIndexedScriptRequestBuilder builder = client.preparePutIndexedScript();
+
+        if (options != null) {
+            if (options.getScriptLang() != null) builder.setScriptLang(options.getScriptLang());
+            if (options.getId() != null) builder.setId(options.getId());
+            if (options.getSource() != null) builder.setSource(options.getSource().encode().getBytes(CHARSET_UTF8));
+        }
+
+        builder.execute(new ActionListener<PutIndexedScriptResponse>() {
+            @Override
+            public void onResponse(PutIndexedScriptResponse putIndexedScriptResponse) {
+                JsonObject json = new JsonObject()
+                        .put(CONST_INDEX, putIndexedScriptResponse.getIndex())
+                        .put(CONST_SCRIPT_LANG, putIndexedScriptResponse.getScriptLang())
+                        .put(CONST_ID, putIndexedScriptResponse.getId())
+                        .put(CONST_IS_CREATED, putIndexedScriptResponse.isCreated())
+                        .put(CONST_VERSION, putIndexedScriptResponse.getVersion());
+                resultHandler.handle(Future.succeededFuture(json));
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                resultHandler.handle(Future.failedFuture(t));
+            }
+        });
     }
 
     protected JsonObject readResponse(ToXContent toXContent) {

--- a/src/main/resources/vertx-elasticsearch-service-js/elastic_search_service.js
+++ b/src/main/resources/vertx-elasticsearch-service-js/elastic_search_service.js
@@ -26,6 +26,7 @@ var GetOptions = com.englishtown.vertx.elasticsearch.GetOptions;
 var SearchOptions = com.englishtown.vertx.elasticsearch.SearchOptions;
 var SearchScrollOptions = com.englishtown.vertx.elasticsearch.SearchScrollOptions;
 var DeleteOptions = com.englishtown.vertx.elasticsearch.DeleteOptions;
+var PutIndexedScriptOptions = com.englishtown.vertx.elasticsearch.PutIndexedScriptOptions;
 
 /**
  ElasticSearch service
@@ -185,6 +186,26 @@ var ElasticSearchService = function(j_val) {
     var __args = arguments;
     if (__args.length === 5 && typeof __args[0] === 'string' && typeof __args[1] === 'string' && typeof __args[2] === 'string' && typeof __args[3] === 'object' && typeof __args[4] === 'function') {
       j_elasticSearchService["delete(java.lang.String,java.lang.String,java.lang.String,com.englishtown.vertx.elasticsearch.DeleteOptions,io.vertx.core.Handler)"](index, type, id, options != null ? new DeleteOptions(new JsonObject(JSON.stringify(options))) : null, function(ar) {
+      if (ar.succeeded()) {
+        resultHandler(utils.convReturnJson(ar.result()), null);
+      } else {
+        resultHandler(null, ar.cause());
+      }
+    });
+    } else utils.invalidArgs();
+  };
+
+  /**
+   Indexes a script on elasticsearch
+
+   @public
+   @param options {Object} the options for the script 
+   @param resultHandler {function} result handler callback 
+   */
+  this.putIndexedScript = function(options, resultHandler) {
+    var __args = arguments;
+    if (__args.length === 2 && typeof __args[0] === 'object' && typeof __args[1] === 'function') {
+      j_elasticSearchService["putIndexedScript(com.englishtown.vertx.elasticsearch.PutIndexedScriptOptions,io.vertx.core.Handler)"](options != null ? new PutIndexedScriptOptions(new JsonObject(JSON.stringify(options))) : null, function(ar) {
       if (ar.succeeded()) {
         resultHandler(utils.convReturnJson(ar.result()), null);
       } else {

--- a/src/test/java/com/englishtown/vertx/elasticsearch/PutIndexedScriptOptionsTest.java
+++ b/src/test/java/com/englishtown/vertx/elasticsearch/PutIndexedScriptOptionsTest.java
@@ -1,0 +1,62 @@
+package com.englishtown.vertx.elasticsearch;
+
+import io.vertx.core.json.JsonObject;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit tests for {@link PutIndexedScriptOptions}
+ */
+public class PutIndexedScriptOptionsTest {
+
+    private static String sampleId;
+    private static String sampleScriptLang;
+    private static JsonObject sampleSource;
+
+    private static PutIndexedScriptOptions pojo;
+    private static JsonObject json;
+
+    private static PutIndexedScriptOptions pojoCopy;
+    private static JsonObject jsonCopy;
+
+    @BeforeClass
+    public static void before() {
+
+        sampleId = "12345";
+        sampleScriptLang = "groovy";
+        sampleSource = new JsonObject().put("sample", "source");
+
+        pojo = new PutIndexedScriptOptions();
+        pojo.setId(sampleId);
+        pojo.setScriptLang(sampleScriptLang);
+        pojo.setSource(sampleSource);
+
+        pojoCopy = new PutIndexedScriptOptions(pojo);
+
+        json = pojo.toJson();
+        jsonCopy = pojoCopy.toJson();
+    }
+
+    @Test
+    public void testGetProperties() {
+        assertEquals(json.getString(PutIndexedScriptOptions.JSON_FIELD_ID), sampleId);
+        assertEquals(json.getString(PutIndexedScriptOptions.JSON_FIELD_SCRIPT_LANG), sampleScriptLang);
+        assertEquals(json.getJsonObject(PutIndexedScriptOptions.JSON_FIELD_SOURCE).encode(), sampleSource.encode());
+
+    }
+
+    @Test
+    public void testSetProperties() {
+        assertEquals(pojo.getId(), json.getString(PutIndexedScriptOptions.JSON_FIELD_ID));
+        assertEquals(pojo.getScriptLang(), json.getString(PutIndexedScriptOptions.JSON_FIELD_SCRIPT_LANG));
+        assertEquals(pojo.getSource().encode(), json.getJsonObject(PutIndexedScriptOptions.JSON_FIELD_SOURCE).encode());
+    }
+
+    @Test
+    public void testCopy() {
+        assertEquals(json.encode(), jsonCopy.encode());
+    }
+
+}


### PR DESCRIPTION
This is related to #13 , #14 .

This method would allow storing indexed scripts in elasticsearch, which include search templates so that they can be accessed by name.

Includes a new data object `PutIndexedScriptOptions` that is unit tested.

It may make sense to try to write an integration test for this as well though. That still needs to be done.
