### PR TITLE
Elastic Search v 2.4.1 upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,11 +13,11 @@
 
     <properties>
         <vertx.version>3.3.3</vertx.version>
-        <es.version>2.2.0</es.version>
-        <lucene.version>5.4.1</lucene.version>
+        <es.version>2.4.1</es.version>
+        <lucene.version>5.5.2</lucene.version>
         <vertx.hk2.version>2.4.0</vertx.hk2.version>
-        <vertx.guice.version>2.3.0</vertx.guice.version>
-        <when.version>4.1.1</when.version>
+        <vertx.guice.version>2.3.1</vertx.guice.version>
+        <when.version>4.2.0</when.version>
 
         <!--Vert.x codegen does not play nice with maven-compiler-plugin 3.2-->
         <maven.compiler.plugin.version>3.1</maven.compiler.plugin.version>


### PR DESCRIPTION
The changes here are to make this library work nicely with Elastic Search v 2.4.1. 
Currently the lib throws `Java.lang.NoSuchFieldError:` LUCENE_4` when used with ES 2.4.1

Elastic Search lib -> 2.4.1
Lucene -> 5.5.2 (corresponding to ES 2.4.1)


